### PR TITLE
Allow custom wordlists to be used (fixes #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ numbers.
 
 ## Usage
 * Build the project: `stack build`.
-* Generate a passphrase: `stack exec -- passphrase`.
+* Generate a passphrase: `stack exec -- passphrase [WORDLIST]`.
 
 To run the test suite, run `stack test`.
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,15 +1,42 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 module Main where
 
 import           Control.Monad (replicateM)
+import           Options.Applicative
 import           Passphrase    (passphrase, rollDice)
 import           RIO
 import qualified RIO.Text      as T
 
+data Arguments = Arguments
+  { wordlistFilePath :: FilePath
+  }
+
+defaultWordlist :: FilePath
+defaultWordlist = "data/eff-large-wordlist.txt"
+
 main :: IO ()
 main = do
-  wordlist <- T.unpack <$> readFileUtf8 "data/eff-large-wordlist.txt"
+  Arguments {..} <- execParser argumentsInfo
+  wordlist <- T.unpack <$> readFileUtf8 wordlistFilePath
   dice <- replicateM 6 $ rollDice 5 1 6
   runSimpleApp $ do
     logInfo . display . T.pack $ passphrase wordlist dice
+
+argumentsInfo :: ParserInfo Arguments
+argumentsInfo =
+  info (helper <*> arguments) $
+       fullDesc
+    <> header "Passphrase"
+    <> progDesc "Diceware passphrase generator"
+
+arguments :: Parser Arguments
+arguments = Arguments
+  <$> wordlistFilePathArgument
+  where
+    wordlistFilePathArgument =
+      strArgument $
+           help "Word list file"
+        <> value defaultWordlist
+        <> metavar "WORDFILE"

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -16,20 +16,6 @@ data Arguments = Arguments
 defaultWordlist :: FilePath
 defaultWordlist = "data/eff-large-wordlist.txt"
 
-main :: IO ()
-main = do
-  Arguments {..} <- execParser argumentsInfo
-  wordlist <- T.unpack <$> readFileUtf8 wordlistFilePath
-  dice <- replicateM 6 $ rollDice 5 1 6
-  runSimpleApp $ do
-    logInfo . display . T.pack $ passphrase wordlist dice
-
-argumentsInfo :: ParserInfo Arguments
-argumentsInfo =
-  info (helper <*> arguments) $
-       fullDesc
-    <> progDesc "Strong six-word Diceware passphrase generator"
-
 arguments :: Parser Arguments
 arguments = Arguments
   <$> wordlistFilePathArgument
@@ -39,3 +25,17 @@ arguments = Arguments
            help "Word list file"
         <> value defaultWordlist
         <> metavar "WORDFILE"
+
+argumentsInfo :: ParserInfo Arguments
+argumentsInfo =
+  info (helper <*> arguments) $
+       fullDesc
+    <> progDesc "Strong six-word Diceware passphrase generator"
+
+main :: IO ()
+main = do
+  Arguments {..} <- execParser argumentsInfo
+  wordlist <- T.unpack <$> readFileUtf8 wordlistFilePath
+  dice <- replicateM 6 $ rollDice 5 1 6
+  runSimpleApp $ do
+    logInfo . display . T.pack $ passphrase wordlist dice

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,7 +10,7 @@ import           RIO
 import qualified RIO.Text            as T
 
 data Arguments = Arguments
-  { wordlistFilePath :: FilePath
+  { argumentsWordlist :: FilePath
   }
 
 defaultWordlist :: FilePath
@@ -35,7 +35,7 @@ argumentsInfo =
 main :: IO ()
 main = do
   Arguments {..} <- execParser argumentsInfo
-  wordlist <- T.unpack <$> readFileUtf8 wordlistFilePath
+  wordlist <- T.unpack <$> readFileUtf8 argumentsWordlist
   dice <- replicateM 6 $ rollDice 5 1 6
   runSimpleApp $ do
     logInfo . display . T.pack $ passphrase wordlist dice

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -22,9 +22,9 @@ arguments = Arguments
     where
       wordlistFilePathArgument =
         strArgument $
-          help "Word list file"
+          help "Wordlist file"
           <> value defaultWordlist
-          <> metavar "WORDFILE"
+          <> metavar "WORDLIST"
 
 argumentsInfo :: ParserInfo Arguments
 argumentsInfo =

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -28,7 +28,6 @@ argumentsInfo :: ParserInfo Arguments
 argumentsInfo =
   info (helper <*> arguments) $
        fullDesc
-    <> header "Passphrase"
     <> progDesc "Diceware passphrase generator"
 
 arguments :: Parser Arguments

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -9,7 +9,7 @@ import           Passphrase          (passphrase, rollDice)
 import           RIO
 import qualified RIO.Text            as T
 
-data Arguments = Arguments
+newtype Arguments = Arguments
   { argumentsWordlist :: FilePath
   }
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -19,17 +19,17 @@ defaultWordlist = "data/eff-large-wordlist.txt"
 arguments :: Parser Arguments
 arguments = Arguments
   <$> wordlistFilePathArgument
-  where
-    wordlistFilePathArgument =
-      strArgument $
-           help "Word list file"
-        <> value defaultWordlist
-        <> metavar "WORDFILE"
+    where
+      wordlistFilePathArgument =
+        strArgument $
+          help "Word list file"
+          <> value defaultWordlist
+          <> metavar "WORDFILE"
 
 argumentsInfo :: ParserInfo Arguments
 argumentsInfo =
   info (helper <*> arguments) $
-       fullDesc
+    fullDesc
     <> progDesc "Strong six-word Diceware passphrase generator"
 
 main :: IO ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -28,7 +28,7 @@ argumentsInfo :: ParserInfo Arguments
 argumentsInfo =
   info (helper <*> arguments) $
        fullDesc
-    <> progDesc "Diceware passphrase generator"
+    <> progDesc "Strong six-word Diceware passphrase generator"
 
 arguments :: Parser Arguments
 arguments = Arguments

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RecordWildCards   #-}
 module Main where
 
-import           Control.Monad (replicateM)
+import           Control.Monad       (replicateM)
 import           Options.Applicative
-import           Passphrase    (passphrase, rollDice)
+import           Passphrase          (passphrase, rollDice)
 import           RIO
-import qualified RIO.Text      as T
+import qualified RIO.Text            as T
 
 data Arguments = Arguments
   { wordlistFilePath :: FilePath

--- a/package.yaml
+++ b/package.yaml
@@ -17,6 +17,7 @@ description:         Please see the README on GitHub at <https://github.com/majj
 dependencies:
 - base >= 4.7 && < 5
 - cryptonite
+- optparse-applicative
 - rio
 
 library:


### PR DESCRIPTION
This provides a basic optparse-applicative argument parser:

```
$ passphrase --help
Passphrase

Usage: passphrase [WORDFILE]
  Diceware passphrase generator

Available options:
    -h,--help                Show this help text
    WORDFILE                 Word list file
```

---

When WORDFILE is not present, it fails the same way as when the default is not present:

```
$ passphrase data/nonexistent.txt
passphrase: data/nonexistent.txt: openFile: does not exist (No such file or directory)
```

I'd like to address that, but since it is also the behavior for the default wordlist file, perhaps address it separately?

---

When WORDFILE does not decode properly, bad things happen:

```
$ curl -o data/memory-alpha_8k_2018.txt https://www.eff.org/files/2018/08/29/memory-alpha_8k_2018.txt
$ file data/memory-alpha_8k_2018.txt
data/memory-alpha_8k_2018.txt: Non-ISO extended-ASCII text, with CRLF, CR line terminators

$ passphrase data/memory-alpha_8k_2018.txt
passphrase: data/memory-alpha_8k_2018.txt: hGetContents: invalid argument (invalid byte sequence)
```

Perhaps address both types of nice error messages (file not found, decoding error) as one separate, combined issue?

---

When WORDFILE does decode, but does not contain the expected format, it fails silently:

```
$ touch data/empty.txt; passphrase data/empty.txt

```

I suppose that is more graceful, but not very informative.